### PR TITLE
Change webHMI name to Loupe UX

### DIFF
--- a/CmdLinePackageHmi.py
+++ b/CmdLinePackageHmi.py
@@ -8,7 +8,7 @@
 """
 @title CmdLinePackageHmi
 @description This python script takes in command line arguments 
-and packages a webHMI-based HMI
+and packages a Loupe UX-based HMI
 
 0.1.0 - Synchronize all script versions
 0.0.1 - Initial release
@@ -33,7 +33,7 @@ import _version
 def main():
 
     # Parse arguments from the command line 
-    parser = argparse.ArgumentParser(description='Package up a webHMI-based HMI')
+    parser = argparse.ArgumentParser(description='Package up a Loupe UX-based HMI')
     # High-level application information. 
     parser.add_argument('-s', '--source', type=str, help='Source folder where the HMI files are located (i.e. where main package.json is located)', default='C:/Projects/Publisher/Project/HMIApp/Electron')
     parser.add_argument('-o', '--output', type=str, help='Destination folder where packaged files are placed')

--- a/Files/InnoInstaller.iss
+++ b/Files/InnoInstaller.iss
@@ -78,7 +78,7 @@ Type: filesandordirs; Name: "{app}"
 #if IncludeHmi == "yes"
 
     [Components]
-    Name: "HMI"; Description: "webHMI user interface"; Types: full custom;
+    Name: "HMI"; Description: "Loupe UX user interface"; Types: full custom;
 
     [Files]
     Source: {#HMIDirectory}\*; DestDir: "{app}\HMI"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: HMI;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The core capabilities live in the [ASTools](./ASTools.py) script, which contains
 - [CmdLineExportLib.py](CmdLineExportLib.py): export Automation Studio libraries into shareable binary or source formats. 
 - [CmdLineGetSafetyCrc.py](CmdLineGetSafetyCrc.py): retrieve the CRC of the specified B&R Safe Application in a project. 
 - [CmdLineGetVersion.py](CmdLineGetVersion.py): retrieve the build version of an AS project. 
-- [CmdLinePackageHmi.py](CmdLinePackageHmi.py): package a webHMI-based HMI for distribution. 
+- [CmdLinePackageHmi.py](CmdLinePackageHmi.py): package a Loupe UX-based HMI for distribution. 
 - [CmdLineRunUnitTests.py](CmdLineRunUnitTests.py): run the unit tests that are defined in the Automation Studio project. Note that this wrapper uses the [UnitTestTools.py](UnitTestTools.py) backend script. 
 
 For a more detailed look at each script's API, please call the script with the `-h` argument. For example, `python CmdLineBuild.py -h`. 


### PR DESCRIPTION
This PR removes references to the old webHMI name, and replaces them with the new Loupe UX name.