### PR TITLE
Fix PVIReturnCodeText uncaught error if unknown error code

### DIFF
--- a/ASTools.py
+++ b/ASTools.py
@@ -206,7 +206,7 @@ def CreateARSimStructure(RUCPackage:str, destination:str, version:str, startSim:
             # This because silent and autoclose mode do not support starting arsim
             pid = subprocess.Popen(os.path.join(destination, 'ar000loader.exe'), stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, creationflags=0x00000008)
     else:
-        logging.debug(f'Error in creating ARSimStructure code {process.returncode}: {PVIReturnCodeText[process.returncode]}')
+        logging.debug(f'Error in creating ARSimStructure code {process.returncode}: {PVIReturnCodeText.get(process.returncode)}')
     
     return process
 


### PR DESCRIPTION
## What:

Uses the dict's get so if unknown error code we do not cause an exception. In the case the key does not exist `None` will be returned instead of an exception. 

## Why:

This will prevent ASPython throwing an exception