### PR TITLE
Adapt task element path to be relative to Logical

### DIFF
--- a/ASTools.py
+++ b/ASTools.py
@@ -1160,6 +1160,10 @@ class SwDeploymentTable(xmlAsFile):
         language = task.type
         # Split the path, and add to it, since cpu.sw expects a '.' separated path. 
         splitPath = os.path.normpath(taskFolder).split(os.sep)
+        for i, part in enumerate(splitPath):
+            if part.lower() == "logical":
+                splitPath = splitPath[i+1:] # For task element, path must be relative to Logical folder,
+                break                       #   so if "logical" found, get the path parts that follow 
         splitPath.append(taskName)
         splitPath.append('prg')
         # Create the element from the provided arguments. 


### PR DESCRIPTION
## What:
Add a check to see if path includes Logical. If so, path is modified.

## Why:
For creating a task element, the path in the element must be relative to the Logical folder for AS to build it.

E.g.
The if path passed into `_createTaskElement` is 
`./Logical/Infrastructure/RevInfo`
the modified path would be
`Infrastructure/RefInfo`