### PR TITLE
Make building RUC package optional

### DIFF
--- a/ASTools.py
+++ b/ASTools.py
@@ -97,11 +97,11 @@ def ASProjetGetConfigs(project: str) -> [str]:
 
     return configs
 
-def batchBuildAsProject(project, ASPath:str, configurations=None, buildMode='Build', tempPath='', logPath='', binaryPath='', simulation=False, additionalArg:Union[str,list,tuple]=None) -> subprocess.CompletedProcess:
+def batchBuildAsProject(project, ASPath:str, configurations=None, buildMode='Build', buildRUCPackage=True, tempPath='', logPath='', binaryPath='', simulation=False, additionalArg:Union[str,list,tuple]=None) -> subprocess.CompletedProcess:
     if configurations is None: configurations = []
 
     for config in configurations:
-        completedProcess = buildASProject(project, ASPath, configuration=config, buildMode=buildMode, tempPath=tempPath, logPath=logPath, binaryPath=binaryPath, simulation=simulation, additionalArg=additionalArg)
+        completedProcess = buildASProject(project, ASPath, configuration=config, buildMode=buildMode, buildRUCPackage=buildRUCPackage, tempPath=tempPath, logPath=logPath, binaryPath=binaryPath, simulation=simulation, additionalArg=additionalArg)
         if completedProcess.returncode > ASReturnCodes["Warnings"]:
             # Call out the end of a failed build
             logging.info(f'Build for configuration {config} has completed with errors, see DEBUG logging for details')
@@ -112,7 +112,7 @@ def batchBuildAsProject(project, ASPath:str, configurations=None, buildMode='Bui
 
     return completedProcess
 
-def buildASProject(project, ASPath:str, configuration='', buildMode='Build', tempPath='', binaryPath='', logPath='', simulation=False, additionalArg:Union[str,list,tuple]=None) -> subprocess.CompletedProcess:
+def buildASProject(project, ASPath:str, configuration='', buildMode='Build', buildRUCPackage=True, tempPath='', binaryPath='', logPath='', simulation=False, additionalArg:Union[str,list,tuple]=None) -> subprocess.CompletedProcess:
     
     commandLine = []
     commandLine.append(ASPath)
@@ -140,7 +140,8 @@ def buildASProject(project, ASPath:str, configuration='', buildMode='Build', tem
     if simulation:
         commandLine.append('-simulation')
 
-    commandLine.append('-buildRUCPackage')
+    if buildRUCPackage:
+        commandLine.append('-buildRUCPackage')
 
     if additionalArg:
         if type(additionalArg) is str:
@@ -780,7 +781,7 @@ class Project(xmlAsFile):
 
         return exportInfo
 
-    def build(self, *configNames, buildMode='Build', tempPath='', binaryPath='', simulation=False, additionalArgs:Union[str,list,tuple]=None):
+    def build(self, *configNames, buildMode='Build', buildRUCPackage=True, tempPath='', binaryPath='', simulation=False, additionalArgs:Union[str,list,tuple]=None):
         for configName in configNames:
             simulation_status = self.getHardwareParameter(configName, 'Simulation')
             # Set simulation properly in hardware before building
@@ -790,7 +791,7 @@ class Project(xmlAsFile):
                 self.setHardwareParameter(configName, 'Simulation', str(int(simulation)))
         
         # TODO: Support should be better supported for return status here. Probably a list
-        return batchBuildAsProject(self.path, getASBuildPath(self.ASVersion), configNames, buildMode, tempPath=tempPath, logPath=self.dirPath, binaryPath=binaryPath, simulation=simulation, additionalArg=additionalArgs)
+        return batchBuildAsProject(self.path, getASBuildPath(self.ASVersion), configNames, buildMode, buildRUCPackage, tempPath=tempPath, logPath=self.dirPath, binaryPath=binaryPath, simulation=simulation, additionalArg=additionalArgs)
 
     def createPIP(self, configName, destination):
         logging.info(f'Creating PIP at {destination}')

--- a/CmdLineBuild.py
+++ b/CmdLineBuild.py
@@ -35,6 +35,7 @@ def main():
     parser.add_argument('project', type=str, help='Path to AS project you want to build')
     parser.add_argument('-c','--configuration', nargs='+', type=str, help='AS configuration(s) you want to build')
     parser.add_argument('-bm','--buildMode', type=str, help='Type of build in AS', default='Build', choices=['Rebuild', 'Build','BuildAndTransfer', 'BuildAndCreateCompactFlash', 'None']) 
+    parser.add_argument('-rp','--buildRUCPackage', action='store_false', help='Should RUCPackage be built')
     parser.add_argument('-sim','--simulation', action='store_true', help='Should be built for simulation')
     parser.add_argument('-pip', action='store_true', help='Generate a PIP after the build completes')
     parser.add_argument('-l', '--logLevel', type=str.upper, help='Log level', choices=['DEBUG','INFO','WARNING', 'ERROR'], default='')
@@ -53,6 +54,7 @@ def main():
     logging.debug('The project to be built is: %s', args.project)
     logging.debug('The project configuration(s) to be build is: %s', args.configuration)
     logging.debug('The project build mode is: %s', args.buildMode)
+    logging.debug('The RUCPackage will be built: %s', args.buildRUCPackage)
     logging.debug('The project will be built for simulation: %s', args.simulation)
     logging.debug('The log level will be: %s', args.logLevel)
     if args.pip:
@@ -69,7 +71,7 @@ def main():
         #     if project.getHardwareParameter(config, 'Simulation') != '':
         #         project.setHardwareParameter(config, 'Simulation', '0')
 
-        buildStatus = project.build(config, buildMode=args.buildMode, simulation=args.simulation)
+        buildStatus = project.build(config, buildMode=args.buildMode, buildRUCPackage=args.buildRUCPackage, simulation=args.simulation)
 
         if buildStatus.returncode > ASTools.ASReturnCodes['Warnings']:
             sys.exit('Build failed for config {config}')


### PR DESCRIPTION
## What:
So far, there has been no possibility to specify whether the RUCPackage should be built or not. Currently it will always be built.

This PR adds the ability to specify whether to build the RUCPackage via command-line flag while maintaining the current behavior if the flag is omitted.

## Why:
In our workflow for building AS projects under certain conditions there might be building errors in case the RUCPackage is built. Making building the RUCPackage optional will help us prevent the building errors.