### PR TITLE
Add objects to packages as reference

### DIFF
--- a/ASTools.py
+++ b/ASTools.py
@@ -991,6 +991,10 @@ class Package(xmlAsFile):
         
         return self
 
+    def addObjectAsReference(self, path):
+        '''Add file or folder to package and directory as reference'''
+        return self._addPkgObject(path, True)
+
     def addObject(self, path, reference=False):
         '''Copy file or folder to package and directory'''
         name = os.path.basename(path)


### PR DESCRIPTION
## What:
Adds a possibility to add an object to a package as reference.

## Why:
We need a possibility to add objects to a package which are located outside the project as reference. The package class currently offers an `addObject` method which offers a `reference` parameter but this is not passed to the `_addPkgObject` method. Furthermore, the path handling is not suitable for objects located outside the project. Therefore, a new method was added.