### PR TITLE
Support AS6 install paths

### DIFF
--- a/ASTools.py
+++ b/ASTools.py
@@ -923,7 +923,17 @@ class Project(xmlAsFile):
     @staticmethod
     def _parseASVersion(apj:str) -> str:
         result = re.search('<?AutomationStudio Version="(.*)" ', apj).group(1).split('.')
-        version = ''.join(result[0:2])     
+        # AS <= 4.x installs to versioned folders like AS41, AS45, AS46
+        # (major + minor). AS 6.x installs into a single AS6 folder, with
+        # minor revisions (6.0, 6.1, 6.5, ...) sharing one install path.
+        try:
+            major = int(result[0])
+        except (ValueError, IndexError):
+            major = 0
+        if major >= 6:
+            version = result[0]
+        else:
+            version = ''.join(result[0:2])
         return 'AS' + version
 
     def getHardwareParameter(self, config, paramName) -> str:

--- a/ASTools.py
+++ b/ASTools.py
@@ -69,8 +69,33 @@ PVIReturnCodeText = {
     28341: 'Transfer to the corresponding target system is not possible since the AR version on the target system does not yet support the transfer mode'
 }
 
+# Candidate base directories where B&R Automation Studio may be installed.
+# AS <= 4.x defaults to C:\BrAutomation. AS 6 changed the default to
+# C:\Program Files (x86)\BRAutomation (note: no space in "BRAutomation").
+_AS_BASE_CANDIDATES = [
+    "C:\\BrAutomation",
+    "C:\\Program Files (x86)\\BRAutomation",
+    "C:\\Program Files\\BRAutomation",
+]
+
+def _findASBase(version:str='') -> str:
+    """Return the base BrAutomation directory.
+
+    If a specific version is provided, prefer a base that actually contains
+    a folder for that version. Otherwise return the first base that exists.
+    Falls back to the legacy default 'C:\\BrAutomation' if none are found.
+    """
+    if version and version.lower() != 'base':
+        for base in _AS_BASE_CANDIDATES:
+            if os.path.isdir(os.path.join(base, version.upper())):
+                return base
+    for base in _AS_BASE_CANDIDATES:
+        if os.path.isdir(base):
+            return base
+    return _AS_BASE_CANDIDATES[0]
+
 def getASPath(version:str) -> str:
-    base = "C:\\BrAutomation"
+    base = _findASBase(version)
     if version.lower() == 'base':
         return base
     else:


### PR DESCRIPTION
AS6 installs to 'C:\Program Files (x86)\BRAutomation' instead of the legacy 'C:\BrAutomation'. getASPath() now probes a list of candidate base directories and prefers the one containing the requested AS version folder, falling back to the legacy default. Preserves behavior for AS<=4.x.

## What:
Describe what the changes are.

## Why:
Describe the improvement(s) that these changes bring. If applicable, describe the reasoning behind key implementation details.