### PR TITLE
Fix namespace on newly created XML elements in library and deployment

### DIFF
--- a/aspython/deployment.py
+++ b/aspython/deployment.py
@@ -60,7 +60,7 @@ class SwDeploymentTable(xmlAsFile):
         }
         for attributeName in attributeOverrides:
             attributes[attributeName] = attributeOverrides[attributeName]
-        element = ET.Element('LibraryObject', attrib=attributes)
+        element = ET.Element(self.nameSpaceFormatted + 'LibraryObject', attrib=attributes)
         element.tail = "\n"
         return element
 
@@ -83,7 +83,7 @@ class SwDeploymentTable(xmlAsFile):
             'Language': language,
             'Debugging': 'true',
         }
-        element = ET.Element('Task', attrib=attributes)
+        element = ET.Element(self.nameSpaceFormatted + 'Task', attrib=attributes)
         element.tail = "\n"
         return element
 

--- a/aspython/library.py
+++ b/aspython/library.py
@@ -85,7 +85,7 @@ class Library(xmlAsFile):
     def addDependency(self, *dependency):
         deps_container = self.find('Dependencies')
         if deps_container is None:
-            deps_container = ET.SubElement(self.root, 'Dependencies')
+            deps_container = ET.SubElement(self.root, self.nameSpaceFormatted + 'Dependencies')
         for dependent in dependency:
             if not isinstance(dependent, Dependency):
                 raise TypeError('Expected Dependency class got', type(dependent))
@@ -184,14 +184,13 @@ class Library(xmlAsFile):
         element.tail = "\n"
         return element
 
-    @staticmethod
-    def _createDependencyElement(dependency: Dependency):
+    def _createDependencyElement(self, dependency: Dependency):
         attributes = {'ObjectName': dependency.name}
         if dependency.minVersion:
             attributes['FromVersion'] = dependency.minVersion
         if dependency.maxVersion:
             attributes['ToVersion'] = dependency.maxVersion
-        return ET.Element('Dependency', attributes)
+        return ET.Element(self.nameSpaceFormatted + 'Dependency', attributes)
 
     @staticmethod
     def _getXmlTag(package: ET.ElementTree) -> str:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,41 @@
+"""Tests for aspython.deployment.SwDeploymentTable."""
+from unittest.mock import patch
+
+import pytest
+
+from aspython.deployment import SwDeploymentTable
+
+# Minimal cpu.sw with all 8 TaskClass slots and a Libraries section so that
+# SwDeploymentTable.__init__ finds them all and skips its write-and-reload path.
+_SW_XML = """\
+<?xml version='1.0' encoding='utf-8'?>
+<SwConfiguration xmlns="http://br-automation.co.at/AS/SwConfiguration" Version="1.0.0.0">
+  <TaskClass Name="Cyclic#1"/>
+  <TaskClass Name="Cyclic#2"/>
+  <TaskClass Name="Cyclic#3"/>
+  <TaskClass Name="Cyclic#4"/>
+  <TaskClass Name="Cyclic#5"/>
+  <TaskClass Name="Cyclic#6"/>
+  <TaskClass Name="Cyclic#7"/>
+  <TaskClass Name="Cyclic#8"/>
+  <Libraries/>
+</SwConfiguration>"""
+
+_PATCH_PATH = "aspython.deployment.getLibraryPathInPackage"
+_PATCH_TYPE = "aspython.deployment.getLibraryType"
+
+
+@pytest.fixture
+def sw_table(tmp_path):
+    sw_path = tmp_path / "cpu.sw"
+    sw_path.write_text(_SW_XML, encoding="utf-8")
+    with patch(_PATCH_PATH, return_value="/fake/TestLib"), patch(_PATCH_TYPE, return_value="ANSIC"):
+        return SwDeploymentTable(str(sw_path))
+
+
+def test_deploy_library_adds_entry(sw_table):
+    with patch(_PATCH_PATH, return_value="/fake/TestLib"), patch(_PATCH_TYPE, return_value="ANSIC"):
+        sw_table.deployLibrary("/some/Libraries/MyLibs", "TestLib")
+
+    # Newly deployed library is visible in-memory without a write+reload roundtrip.
+    assert "TestLib" in sw_table.libraries

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,28 @@
+"""Tests for aspython.library.Library."""
+import pytest
+
+from aspython.library import Library
+from aspython.models import Dependency
+
+_LIBRARY_XML = """\
+<?xml version='1.0' encoding='utf-8'?>
+<Library xmlns="http://br-automation.co.at/AS/Library" SubType="ANSIC" Version="1.0.0.0" Description="">
+  <Files/>
+</Library>"""
+
+
+@pytest.fixture
+def library_file(tmp_path):
+    lib_dir = tmp_path / "TestLib"
+    lib_dir.mkdir()
+    lby = lib_dir / "ANSIC.lby"
+    lby.write_text(_LIBRARY_XML, encoding="utf-8")
+    return Library(str(lby))
+
+
+def test_add_dependency_roundtrip(library_file):
+    dep = Dependency(name="runtime", minVersion="", maxVersion="")
+    library_file.addDependency(dep)
+
+    # Newly added elements are visible in-memory without a write+reload roundtrip.
+    assert "runtime" in library_file.dependencyNames


### PR DESCRIPTION
## What changed

Four `ET.Element` / `ET.SubElement` calls were creating elements **without** the Automation Studio namespace prefix, so the new elements were invisible to `find`/`findall` queries until the file was written to disk and re-read.

| File | Method | Element |
|---|---|---|
| `aspython/library.py` | `addDependency` | `<Dependencies>` container |
| `aspython/library.py` | `_createDependencyElement` | `<Dependency>` child |
| `aspython/deployment.py` | `_createLibraryElement` | `<LibraryObject>` |
| `aspython/deployment.py` | `_createTaskElement` | `<Task>` |

The fix prefixes each tag with `self.nameSpaceFormatted` (e.g. `{http://br-automation.co.at/AS/Library}`), matching the approach already used by `_convertXmlTag` in `library.py`.

`_createDependencyElement` was a `@staticmethod`; it becomes a regular instance method to access `self.nameSpaceFormatted`.

## Why

`xmlAsFile.findall` prepends the namespace to every XPath segment. Elements created without a namespace didn't match, causing silent failures that only resolved after a write+reload roundtrip.

## Tests

Added `tests/test_library.py::test_add_dependency_roundtrip` and `tests/test_deployment.py::test_deploy_library_adds_entry`. Both assert that the mutated state is visible **in-memory** immediately after the call, with no `write()` / `read()` cycle in between.

## Reviewer notes

- No behaviour change beyond fixing the silent namespace mismatch — callers that relied on the write+reload workaround still work because the file is written as before.
- `_addRootLevelElement` (used by `SwDeploymentTable.__init__`) has the same pattern but is out of scope for this PR.