### PR TITLE
Build releases as wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,33 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+  build-wheel:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Build wheel and sdist
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aspython-dist
+          path: dist/
+
+      - name: Attach to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+
   build-exe:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
@@ -43,7 +70,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install package + dev extras
         run: |


### PR DESCRIPTION
This pull request updates the CI workflow to add a new job for building and publishing Python wheels and source distributions upon tagging a release, and upgrades the Python version used in the build process to 3.14.

**Build and Release Process Improvements:**

* Added a `build-wheel` job to the workflow, which builds the Python wheel and source distribution, uploads them as artifacts, and attaches them to the GitHub release when a tag starting with `v` is pushed. (`.github/workflows/ci.yml`)

**Python Version Update:**

* Updated the Python version used in both the new `build-wheel` job and the existing `build-exe` job from 3.12 to 3.14 for consistency and to utilize the latest features. (`.github/workflows/ci.yml`)
 

## Why:

This will allow python package to be installed via wheel from release